### PR TITLE
Force HTTPS for corrected Imgur URLs

### DIFF
--- a/utility/ulrprocessor.go
+++ b/utility/ulrprocessor.go
@@ -47,6 +47,7 @@ func (p imgurProcessor) CanProcess(str string) bool {
 
 func (p imgurProcessor) Process(str string) string {
 	URL, _ := url.Parse(str)
+	URL.Scheme = "https"
 	URL.Path += "v"
 
 	return URL.String()


### PR DESCRIPTION
Ensure that when [CorrectionBot](https://github.com/NelsonLeDuc/CorrectionBot) corrects user-posted Imgur URLs it outputs only HTTPS links.
